### PR TITLE
Add excludedPrefixes option and improve performance

### DIFF
--- a/Serilog.Enrichers.CallerInfo.Tests/CallerInfoTests.cs
+++ b/Serilog.Enrichers.CallerInfo.Tests/CallerInfoTests.cs
@@ -25,7 +25,7 @@ namespace Serilog.Enrichers.CallerInfo.Tests
         public void LocalFunctionsAreNotIncluded()
         {
             Log.Logger = new LoggerConfiguration()
-                .Enrich.WithCallerInfo(includeFileInfo: true, "Serilog.Enrichers.CallerInfo.Tests", string.Empty)
+                .Enrich.WithCallerInfo(includeFileInfo: true, "Serilog.Enrichers.CallerInfo", string.Empty)
                 .WriteTo.InMemory()
                 .CreateLogger();
 
@@ -41,6 +41,28 @@ namespace Serilog.Enrichers.CallerInfo.Tests
                 .Appearing().Once()
                 .WithProperty("Method").WithValue("LocalFunctionsAreNotIncluded")
                 .And.WithProperty("Namespace").WithValue("Serilog.Enrichers.CallerInfo.Tests.CallerInfoTests");
+        }
+        [Fact]
+        public void PrivateFunctionShouldBeAvailable()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .Enrich.WithCallerInfo(includeFileInfo: true, "Serilog.Enrichers.CallerInfo", string.Empty)
+                .WriteTo.InMemory()
+                .CreateLogger();
+
+            
+
+            PrivateLocalFunction("i like turtles");
+
+            InMemorySink.Instance.Should()
+                .HaveMessage("i like turtles")
+                .Appearing().Once()
+                .WithProperty("Method").WithValue(nameof(PrivateLocalFunction))
+                .And.WithProperty("Namespace").WithValue("Serilog.Enrichers.CallerInfo.Tests.CallerInfoTests");
+        }
+        static void PrivateLocalFunction(string arg)
+        {
+            Log.Information(arg);
         }
     }
 }

--- a/Serilog.Enrichers.CallerInfo/EnricherConfiguration.cs
+++ b/Serilog.Enrichers.CallerInfo/EnricherConfiguration.cs
@@ -33,16 +33,19 @@ namespace Serilog.Enrichers.CallerInfo
         /// <param name="assemblyPrefix">The prefix of assemblies to allow when finding the calling method in the stack trace.</param>
         /// <param name="prefix">An optional prefix to prepend to all property values.</param>
         /// <param name="startingAssembly">The optional name of the assembly from which to discover other related ones with the given prefix. If not provided, the calling assembly of this method is used as the starting point.</param>
+        /// <param name="excludedPrefixes">Which assembly prefixes to exclude when finding the calling method in the stack trace.</param>
         /// <returns>The modified logger configuration.</returns>
         public static LoggerConfiguration WithCallerInfo(
             this LoggerEnrichmentConfiguration enrichmentConfiguration,
             bool includeFileInfo,
             string assemblyPrefix,
             string prefix = "",
-            string startingAssembly = "")
+            string startingAssembly = "",
+            IEnumerable<string> excludedPrefixes = null)
         {
             var startAssembly = string.IsNullOrWhiteSpace(startingAssembly) ? Assembly.GetCallingAssembly() : Assembly.Load(startingAssembly);
-            var referencedAssemblies = GetAssemblies(startAssembly, asm => asm.Name?.StartsWith(assemblyPrefix, StringComparison.OrdinalIgnoreCase) ?? false);
+            var referencedAssemblies = GetAssemblies(startAssembly, asm => asm.Name?.StartsWith(assemblyPrefix, StringComparison.OrdinalIgnoreCase) ?? false, asm =>
+             excludedPrefixes?.Any(excluded => asm?.Name?.StartsWith(excluded, StringComparison.OrdinalIgnoreCase) ?? false) ?? false);
             return enrichmentConfiguration.WithCallerInfo(includeFileInfo, referencedAssemblies, prefix);
         }
 
@@ -50,36 +53,34 @@ namespace Serilog.Enrichers.CallerInfo
         /// Find the assemblies that a starting Assembly references, filtering with some predicate.<br/>
         /// Adapted from <see href="https://stackoverflow.com/a/10253634/2102106"/>
         /// </summary>
-        /// <param name="start">The starting assembly.</param>
+        /// <param name="startingAssembly">The starting assembly.</param>
         /// <param name="filter">A filtering predicate based on the AssemblyName</param>
+        /// <param name="exclude">An exclusion predicate based on the AssemblyName</param>
         /// <returns>The list of referenced Assembly names</returns>
-        private static IEnumerable<string> GetAssemblies(Assembly start, Func<AssemblyName, bool> filter)
+        private static IEnumerable<string> GetAssemblies(Assembly startingAssembly, Func<AssemblyName, bool> filter, Func<AssemblyName, bool> exclude=null)
         {
-            var asmNames = new List<string>();
+            
+            var asmNames = new HashSet<string>(comparer:StringComparer.OrdinalIgnoreCase);
             var stack = new Stack<Assembly>();
-            stack.Push(start);
-
+            stack.Push(startingAssembly);
+            var entryAssembly = Assembly.GetEntryAssembly();
+            if (!startingAssembly.FullName.Equals(entryAssembly?.FullName,StringComparison.OrdinalIgnoreCase))
+            {
+                stack.Push(entryAssembly);
+            }
             do
             {
                 var asm = stack.Pop();
-                if (!filter(asm.GetName()))
+                var assemblyExistsInList = asmNames.Contains(asm.GetName().Name);
+                var assemblyIsNotExcluded = exclude == null || !exclude(asm.GetName());
+                var assemblyIsIncluded = filter(asm.GetName());
+                if (!assemblyExistsInList && assemblyIsIncluded &&assemblyIsNotExcluded )
                 {
-                    continue;
+                    asmNames.Add(asm.GetName().Name);
                 }
-
-                asmNames.Add(asm.GetName().Name);
                 foreach (var reference in asm.GetReferencedAssemblies())
                 {
-                    if (!filter(reference))
-                    {
-                        continue;
-                    }
-
-                    if (!asmNames.Contains(reference.Name))
-                    {
-                        stack.Push(Assembly.Load(reference));
-                        asmNames.Add(reference.Name);
-                    }
+                    stack.Push(Assembly.Load(reference));
                 }
             } while (stack.Count > 0);
 


### PR DESCRIPTION
Hello, I have made some changes to the serilog-enrichers-callerinfo project and I would like to request a pull request. Here are the main features of my changes:

- Add a new excludedPrefixes option to the logger configuration, which allows users to specify prefixes that should not be logged. This can be useful in some cases where excluding prefixes is easier than including them.

- Change the method of getting the calling assembly from GetCallingAssembly to also use GetEntryAssembly, which fixes the problem of logging the wrong assembly name when the logger setup assembly is separated from the actual app assembly.

- Use a HashSet instead of a List to store and check the allowed assemblies, which improves the performance of the logger by reducing the number of comparisons.

I have also added a test and checked if all previous tests are passing. I hope you find these changes useful and acceptable. Please let me know if you have any feedback or questions. Thank you for your time and consideration.